### PR TITLE
Create bga_table_id column and populate it

### DIFF
--- a/ark_nova_stats/api/gql/types/game_log.py
+++ b/ark_nova_stats/api/gql/types/game_log.py
@@ -26,6 +26,10 @@ def game_log_fields() -> dict[str, GraphQLField]:
             GraphQLNonNull(GraphQLString),
             description="The game log.",
         ),
+        "bgaTableId": GraphQLField(
+            GraphQLNonNull(GraphQLInt),
+            description="ID of original table on BGA.",
+        ),
     }
 
 

--- a/ark_nova_stats/api/migrations/BUILD.bazel
+++ b/ark_nova_stats/api/migrations/BUILD.bazel
@@ -21,7 +21,7 @@ py_binary(
     main = "__main__.py",
     visibility = ["//ark_nova_stats/api:__subpackages__"],
     deps = [
-        ":migrate_lib",
+        ":migrate_lib",  # keep
         "//ark_nova_stats:config_py",
         "@py_deps//flask_migrate",
     ],

--- a/ark_nova_stats/api/migrations/BUILD.bazel
+++ b/ark_nova_stats/api/migrations/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@py_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 py_library(
@@ -7,9 +6,11 @@ py_library(
     imports = [".."],
     visibility = ["//:__subpackages__"],
     deps = [
+        "//ark_nova_stats:models_py",
+        "//ark_nova_stats/bga_log_parser:game_log",
         "//base:flask_app_py",
-        requirement("alembic"),
-        requirement("Flask"),
+        "@py_deps//alembic",
+        "@py_deps//flask",
     ],
 )
 
@@ -17,12 +18,11 @@ py_binary(
     name = "binary",
     srcs = glob(["**/*.py"]),  # keep
     data = ["alembic.ini"],
-    imports = [".."],
     main = "__main__.py",
     visibility = ["//ark_nova_stats/api:__subpackages__"],
     deps = [
+        ":migrate_lib",
         "//ark_nova_stats:config_py",
-        "//scripts:wait_for_postgres",  # keep
         "@py_deps//flask_migrate",
     ],
 )

--- a/ark_nova_stats/api/migrations/versions/8c749a7279e7_add_table_id_to_game_logs.py
+++ b/ark_nova_stats/api/migrations/versions/8c749a7279e7_add_table_id_to_game_logs.py
@@ -1,0 +1,56 @@
+"""add-table-id-to-game-logs
+
+Revision ID: 8c749a7279e7
+Revises: 2ce11871a414
+Create Date: 2024-07-27 18:20:31.263830
+
+"""
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+
+from ark_nova_stats.bga_log_parser.game_log import GameLog as BGAGameLog
+from ark_nova_stats.models import GameLog as GameLogModel
+
+# revision identifiers, used by Alembic.
+revision = "8c749a7279e7"
+down_revision = "2ce11871a414"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # First, add a non-unique column.
+    op.add_column(
+        "game_logs",
+        sa.Column(
+            "bga_table_id",
+            sa.Integer,
+            unique=True,
+        ),
+    )
+    for log_model in GameLogModel.query.all():
+        parsed_log = BGAGameLog(**json.loads(log_model.log))
+        table_ids = set(l.table_id for l in parsed_log.data.logs)
+        if len(table_ids) != 1:
+            raise RuntimeError(
+                f"Log {log_model.id} is invalid: there must be exactly one table_id per game log, found: {table_ids}"
+            )
+
+        op.execute(
+            f"update game_logs set bga_table_id={list(table_ids)[0]} where id = {log_model.id} limit 1"
+        )
+
+    op.create_index(
+        "game_logs_bga_table_id",
+        "game_logs",
+        ["bga_table_id"],
+        unique=True,
+    )
+
+
+def downgrade():
+    op.drop_index("game_logs_bga_table_id", "game_logs")
+    op.drop_column("game_logs", "bga_table_id")

--- a/ark_nova_stats/models.py
+++ b/ark_nova_stats/models.py
@@ -24,3 +24,4 @@ class GameLog(db.Model):
         db.TIMESTAMP(timezone=True),
         default=lambda: datetime.datetime.now(tz=datetime.timezone.utc),
     )
+    bga_table_id: Mapped[int]


### PR DESCRIPTION
Creates a new column in the database, `bga_table_id`, that's the table ID on BGA of the game that the replay is for.

We parse the existing replays in a migration and set the column for any pre-existing data.

We also set up a unique index so that we can do lookups of this field later.

Fixes #298.
