### PR TITLE
In Ark game server, enforce validations for conservation project rewards

### DIFF
--- a/ark_nova_stats/game_server/game_server.go
+++ b/ark_nova_stats/game_server/game_server.go
@@ -183,7 +183,6 @@ func (s *gameServer) ValidatePlayerGameState(ctx context.Context, playerGameStat
 	}
 
 	// TODO validations for:
-	// repeated ConservationProjectReward conservation_project_rewards = 7;
 	if errors := s.ValidatePlayerConservationProjectRewards(ctx, playerGameState.ConservationProjectRewards); len(errors) > 0 {
 		return errors
 	}

--- a/ark_nova_stats/game_server/game_server.go
+++ b/ark_nova_stats/game_server/game_server.go
@@ -119,6 +119,10 @@ func (s *gameServer) ValidatePlayerConservationProjectReward(ctx context.Context
 			return []string{"Player has duplicate recurring conservation rewards"}
 		}
 	} else if conservationReward.GetOneTimeReward() != associate.ConservationProjectOneTimeReward_CONSERVATIONPROJECTONETIMEREWARD_UNKNOWN {
+		oneTimeReward := conservationReward.GetOneTimeReward()
+		if _, found := seenOneTimeRewards[oneTimeReward]; found {
+			return []string{"Player has duplicate one-time conservation rewards"}
+		}
 
 	} else {
 		return []string{"Conservation project reward cannot be unknown type"}

--- a/ark_nova_stats/game_server/game_server.go
+++ b/ark_nova_stats/game_server/game_server.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/shaldengeki/monorepo/ark_nova_stats/game_server/game_state_provider"
 
+	"github.com/shaldengeki/monorepo/ark_nova_stats/game_server/proto/server"
 	"github.com/shaldengeki/monorepo/ark_nova_stats/proto/associate"
 	"github.com/shaldengeki/monorepo/ark_nova_stats/proto/game_state"
 	"github.com/shaldengeki/monorepo/ark_nova_stats/proto/player_game_state"
-	"github.com/shaldengeki/monorepo/ark_nova_stats/game_server/proto/server"
 
 	"google.golang.org/grpc"
 )
@@ -113,7 +113,14 @@ func (s *gameServer) ValidatePlayerActionCard(ctx context.Context, actionCard *p
 }
 
 func (s *gameServer) ValidatePlayerConservationProjectReward(ctx context.Context, conservationReward *associate.ConservationProjectReward, seenRecurringRewards map[associate.ConservationProjectRecurringReward]int, seenOneTimeRewards map[associate.ConservationProjectOneTimeReward]int) []string {
-	if conservationReward.GetRecurringReward() == associate.ConservationProjectRecurringReward_CONSERVATIONPROJECTRECURRINGREWARD_UNKNOWN && conservationReward.GetOneTimeReward() == associate.ConservationProjectOneTimeReward_CONSERVATIONPROJECTONETIMEREWARD_UNKNOWN {
+	if conservationReward.GetRecurringReward() != associate.ConservationProjectRecurringReward_CONSERVATIONPROJECTRECURRINGREWARD_UNKNOWN {
+		recurringReward := conservationReward.GetRecurringReward()
+		if _, found := seenRecurringRewards[recurringReward]; found {
+			return []string{"Player has duplicate recurring conservation rewards"}
+		}
+	} else if conservationReward.GetOneTimeReward() != associate.ConservationProjectOneTimeReward_CONSERVATIONPROJECTONETIMEREWARD_UNKNOWN {
+
+	} else {
 		return []string{"Conservation project reward cannot be unknown type"}
 	}
 
@@ -155,7 +162,7 @@ func (s *gameServer) ValidatePlayerGameState(ctx context.Context, playerGameStat
 	}
 
 	// TODO validations for:
-    // repeated ConservationProjectReward conservation_project_rewards = 7;
+	// repeated ConservationProjectReward conservation_project_rewards = 7;
 
 	seenConservationRecurringRewards := map[associate.ConservationProjectRecurringReward]int{}
 	seenConservationOneTimeRewards := map[associate.ConservationProjectOneTimeReward]int{}
@@ -166,19 +173,18 @@ func (s *gameServer) ValidatePlayerGameState(ctx context.Context, playerGameStat
 		}
 	}
 
-    // repeated PartnerZoo partner_zoos = 8;
-    // repeated University universities = 9;
+	// repeated PartnerZoo partner_zoos = 8;
+	// repeated University universities = 9;
 
-    // repeated AnimalCard animals = 10;
-    // repeated SponsorCard sponsors = 11;
+	// repeated AnimalCard animals = 10;
+	// repeated SponsorCard sponsors = 11;
 
-    // PlayerMap map = 12;
+	// PlayerMap map = 12;
 
-    // PlayerHand hand = 13;
+	// PlayerHand hand = 13;
 
 	return []string{}
 }
-
 
 func (s *gameServer) ValidateState(ctx context.Context, request *server.ValidateStateRequest) (*server.ValidateStateResponse, error) {
 	if request.GameState == nil {

--- a/ark_nova_stats/game_server/game_server.go
+++ b/ark_nova_stats/game_server/game_server.go
@@ -183,6 +183,7 @@ func (s *gameServer) ValidatePlayerGameState(ctx context.Context, playerGameStat
 	}
 
 	// TODO validations for:
+	// conservation project rewards don't line up with map
 	if errors := s.ValidatePlayerConservationProjectRewards(ctx, playerGameState.ConservationProjectRewards); len(errors) > 0 {
 		return errors
 	}

--- a/ark_nova_stats/game_server/game_server_test.go
+++ b/ark_nova_stats/game_server/game_server_test.go
@@ -25,7 +25,6 @@ func TestGetState_WhenEmptyRequest_ReturnsError(t *testing.T) {
 	}
 }
 
-
 func TestGetState_WhenEmptyStateProviderGiven_ReturnsEmptyState(t *testing.T) {
 	s := New(game_state_provider.NewEmptyGameStateProvider())
 	r := server.GetStateRequest{GameId: 1}
@@ -237,8 +236,8 @@ func TestValidateState_WhenPlayerGameStatesEmpty_ReturnsError(t *testing.T) {
 
 	r := server.ValidateStateRequest{
 		GameState: &game_state.GameState{
-			Round: 1,
-			BreakMax: 1,
+			Round:            1,
+			BreakMax:         1,
 			PlayerGameStates: playerGameStates,
 		},
 	}
@@ -300,7 +299,7 @@ func TestValidatePlayerGameState_WhenMoneyNegative_ReturnsError(t *testing.T) {
 func TestValidatePlayerGameState_WhenActionCardsEmpty_ReturnsError(t *testing.T) {
 	s := New(nil)
 	state := player_game_state.PlayerGameState{
-		PlayerId: 1,
+		PlayerId:    1,
 		ActionCards: []*player_game_state.PlayerActionCard{},
 	}
 
@@ -419,7 +418,6 @@ func TestValidatePlayerActionCardToken_WhenActionCardTokensUnknownType_ReturnsEr
 	}
 }
 
-
 func TestValidatePlayerActionCardToken_WhenActionCardTokensLessThanOne_ReturnsError(t *testing.T) {
 	s := New(nil)
 	token := player_game_state.PlayerActionCardToken{
@@ -457,6 +455,24 @@ func TestValidatePlayerConservationProjectReward_WhenOneTimeTypeUnknown_ReturnsE
 		},
 	}
 	seenConservationRecurringRewards := map[associate.ConservationProjectRecurringReward]int{}
+	seenConservationOneTimeRewards := map[associate.ConservationProjectOneTimeReward]int{}
+
+	res := s.ValidatePlayerConservationProjectReward(nil, &reward, seenConservationRecurringRewards, seenConservationOneTimeRewards)
+	if len(res) < 1 {
+		t.Fatalf("Should result in a validation error, but got %v", res)
+	}
+}
+
+func TestValidatePlayerConservationProjectReward_WhenDuplicateRecurring_ReturnsError(t *testing.T) {
+	s := New(nil)
+	reward := associate.ConservationProjectReward{
+		Reward: &associate.ConservationProjectReward_RecurringReward{
+			RecurringReward: associate.ConservationProjectRecurringReward_CONSERVATIONPROJECTRECURRINGREWARD_SNAPPING,
+		},
+	}
+	seenConservationRecurringRewards := map[associate.ConservationProjectRecurringReward]int{
+		associate.ConservationProjectRecurringReward_CONSERVATIONPROJECTRECURRINGREWARD_SNAPPING: 1,
+	}
 	seenConservationOneTimeRewards := map[associate.ConservationProjectOneTimeReward]int{}
 
 	res := s.ValidatePlayerConservationProjectReward(nil, &reward, seenConservationRecurringRewards, seenConservationOneTimeRewards)

--- a/ark_nova_stats/game_server/game_server_test.go
+++ b/ark_nova_stats/game_server/game_server_test.go
@@ -502,14 +502,46 @@ func TestValidatePlayerConservationProjectReward_WhenDuplicateOneTime_ReturnsErr
 func TestValidatePlayerConservationProjectReward_WhenTooManyRewards_ReturnsError(t *testing.T) {
 	s := New(nil)
 	rewards := []*associate.ConservationProjectReward{
-		&associate.ConservationProjectReward{},
-		&associate.ConservationProjectReward{},
-		&associate.ConservationProjectReward{},
-		&associate.ConservationProjectReward{},
-		&associate.ConservationProjectReward{},
-		&associate.ConservationProjectReward{},
-		&associate.ConservationProjectReward{},
-		&associate.ConservationProjectReward{},
+		&associate.ConservationProjectReward{
+			Reward: &associate.ConservationProjectReward_OneTimeReward{
+				OneTimeReward: associate.ConservationProjectOneTimeReward_CONSERVATIONPROJECTONETIMEREWARD_AVIARY_REPTILE_HOUSE,
+			},
+		},
+		&associate.ConservationProjectReward{
+			Reward: &associate.ConservationProjectReward_OneTimeReward{
+				OneTimeReward: associate.ConservationProjectOneTimeReward_CONSERVATIONPROJECTONETIMEREWARD_ASSOCIATION_WORKER,
+			},
+		},
+		&associate.ConservationProjectReward{
+			Reward: &associate.ConservationProjectReward_OneTimeReward{
+				OneTimeReward: associate.ConservationProjectOneTimeReward_CONSERVATIONPROJECTONETIMEREWARD_TWELVE_MONEY,
+			},
+		},
+		&associate.ConservationProjectReward{
+			Reward: &associate.ConservationProjectReward_OneTimeReward{
+				OneTimeReward: associate.ConservationProjectOneTimeReward_CONSERVATIONPROJECTONETIMEREWARD_THREE_X,
+			},
+		},
+		&associate.ConservationProjectReward{
+			Reward: &associate.ConservationProjectReward_OneTimeReward{
+				OneTimeReward: associate.ConservationProjectOneTimeReward_CONSERVATIONPROJECTONETIMEREWARD_UNIVERSITY,
+			},
+		},
+		&associate.ConservationProjectReward{
+			Reward: &associate.ConservationProjectReward_OneTimeReward{
+				OneTimeReward: associate.ConservationProjectOneTimeReward_CONSERVATIONPROJECTONETIMEREWARD_AVIARY_REPTILE_HOUSE,
+			},
+		},
+		&associate.ConservationProjectReward{
+			Reward: &associate.ConservationProjectReward_OneTimeReward{
+				OneTimeReward: associate.ConservationProjectOneTimeReward_CONSERVATIONPROJECTONETIMEREWARD_DETERMINATION,
+			},
+		},
+		&associate.ConservationProjectReward{
+			Reward: &associate.ConservationProjectReward_OneTimeReward{
+				OneTimeReward: associate.ConservationProjectOneTimeReward_CONSERVATIONPROJECTONETIMEREWARD_TWO_REPUTATION,
+			},
+		},
 	}
 	res := s.ValidatePlayerConservationProjectRewards(nil, rewards)
 	if len(res) < 1 {

--- a/ark_nova_stats/game_server/game_server_test.go
+++ b/ark_nova_stats/game_server/game_server_test.go
@@ -480,3 +480,21 @@ func TestValidatePlayerConservationProjectReward_WhenDuplicateRecurring_ReturnsE
 		t.Fatalf("Should result in a validation error, but got %v", res)
 	}
 }
+
+func TestValidatePlayerConservationProjectReward_WhenDuplicateOneTime_ReturnsError(t *testing.T) {
+	s := New(nil)
+	reward := associate.ConservationProjectReward{
+		Reward: &associate.ConservationProjectReward_OneTimeReward{
+			OneTimeReward: associate.ConservationProjectOneTimeReward_CONSERVATIONPROJECTONETIMEREWARD_AVIARY_REPTILE_HOUSE,
+		},
+	}
+	seenConservationRecurringRewards := map[associate.ConservationProjectRecurringReward]int{}
+	seenConservationOneTimeRewards := map[associate.ConservationProjectOneTimeReward]int{
+		associate.ConservationProjectOneTimeReward_CONSERVATIONPROJECTONETIMEREWARD_AVIARY_REPTILE_HOUSE: 1,
+	}
+
+	res := s.ValidatePlayerConservationProjectReward(nil, &reward, seenConservationRecurringRewards, seenConservationOneTimeRewards)
+	if len(res) < 1 {
+		t.Fatalf("Should result in a validation error, but got %v", res)
+	}
+}

--- a/ark_nova_stats/game_server/game_server_test.go
+++ b/ark_nova_stats/game_server/game_server_test.go
@@ -498,3 +498,21 @@ func TestValidatePlayerConservationProjectReward_WhenDuplicateOneTime_ReturnsErr
 		t.Fatalf("Should result in a validation error, but got %v", res)
 	}
 }
+
+func TestValidatePlayerConservationProjectReward_WhenTooManyRewards_ReturnsError(t *testing.T) {
+	s := New(nil)
+	rewards := []*associate.ConservationProjectReward{
+		&associate.ConservationProjectReward{},
+		&associate.ConservationProjectReward{},
+		&associate.ConservationProjectReward{},
+		&associate.ConservationProjectReward{},
+		&associate.ConservationProjectReward{},
+		&associate.ConservationProjectReward{},
+		&associate.ConservationProjectReward{},
+		&associate.ConservationProjectReward{},
+	}
+	res := s.ValidatePlayerConservationProjectRewards(nil, rewards)
+	if len(res) < 1 {
+		t.Fatalf("Should result in a validation error, but got %v", res)
+	}
+}


### PR DESCRIPTION
- **In Ark game server, enforce that players cannot have duplicate recurring conservation project rewards**
- **Add validation for duplicate one-time rewards**
- **Enforce validation limiting number of conservation project rewards**
- **Remove comment**
