### PR TITLE
In Ark DB API, when submitting game logs, record game start & end times

### DIFF
--- a/ark_nova_stats/api/gql/types/game_log.py
+++ b/ark_nova_stats/api/gql/types/game_log.py
@@ -112,7 +112,10 @@ def submit_game_logs(
         )
 
     log: GameLogModel = game_log_model(
-        bga_table_id=list(table_ids)[0], log=args["logs"]
+        bga_table_id=list(table_ids)[0],
+        log=args["logs"],
+        game_start=parsed_logs.game_start,
+        game_end=parsed_logs.game_end,
     )
     if app.config["TESTING"] == True:
         log.id = 1

--- a/ark_nova_stats/api/gql/types/game_log.py
+++ b/ark_nova_stats/api/gql/types/game_log.py
@@ -25,6 +25,14 @@ def game_log_bga_table_id_resolver(game_log: GameLogModel, info, **args) -> int:
     return game_log.bga_table_id
 
 
+def game_log_start_resolver(game_log: GameLogModel, info, **args) -> int:
+    return round(game_log.game_start.timestamp())
+
+
+def game_log_end_resolver(game_log: GameLogModel, info, **args) -> int:
+    return round(game_log.game_end.timestamp())
+
+
 def game_log_fields() -> dict[str, GraphQLField]:
     return {
         "id": GraphQLField(
@@ -42,9 +50,21 @@ def game_log_fields() -> dict[str, GraphQLField]:
         ),
         "users": GraphQLField(
             GraphQLNonNull(GraphQLList(user_type)),
+            description="Users who played in this game.",
         ),
         "cards": GraphQLField(
             GraphQLNonNull(GraphQLList(card_type)),
+            description="Cards played in this game.",
+        ),
+        "start": GraphQLField(
+            GraphQLNonNull(GraphQLInt),
+            description="UNIX timestamp when the game started.",
+            resolve=game_log_start_resolver,
+        ),
+        "end": GraphQLField(
+            GraphQLNonNull(GraphQLInt),
+            description="UNIX timestamp when the game ended.",
+            resolve=game_log_end_resolver,
         ),
     }
 

--- a/ark_nova_stats/api/migrations/versions/cfe96b7f8238_add_game_start_end_to_game_logs.py
+++ b/ark_nova_stats/api/migrations/versions/cfe96b7f8238_add_game_start_end_to_game_logs.py
@@ -1,0 +1,58 @@
+"""add-game-start-end-to-game-logs
+
+Revision ID: cfe96b7f8238
+Revises: b240d476fde9
+Create Date: 2024-09-18 21:22:18.098754
+
+"""
+
+import json
+import logging
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import orm
+
+from ark_nova_stats.bga_log_parser.game_log import GameLog as BGAGameLog
+from ark_nova_stats.models import GameLog as GameLogModel
+
+# revision identifiers, used by Alembic.
+revision = "cfe96b7f8238"
+down_revision = "b240d476fde9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "game_logs",
+        sa.Column("game_start", sa.DateTime, nullable=False),
+    )
+    op.add_column(
+        "game_logs",
+        sa.Column("game_end", sa.DateTime, nullable=False),
+    )
+
+    bind = op.get_bind()
+    session = orm.Session(bind=bind)
+
+    logging.info("Processing pre-existing logs.")
+    for log_model in session.query(GameLogModel):
+        logging.info(f"Processing log: {log_model.id}")
+        parsed_log = BGAGameLog(**json.loads(log_model.log))
+        log_model.game_start = parsed_log.game_start
+        log_model.game_end = parsed_log.game_end
+
+    session.commit()
+
+    op.create_index(
+        "game_logs_game_end",
+        "game_logs",
+        ["game_end"],
+    )
+
+
+def downgrade():
+    op.drop_index("game_logs_game_end", "game_logs")
+    op.drop_column("game_logs", "game_start")
+    op.drop_column("game_logs", "game_end")

--- a/ark_nova_stats/bga_log_parser/game_log.py
+++ b/ark_nova_stats/bga_log_parser/game_log.py
@@ -1,3 +1,4 @@
+import datetime
 from dataclasses import dataclass
 from typing import Any, Iterator, Optional
 
@@ -366,3 +367,23 @@ class GameLog:
                 self.parse_player_stats(player_stats) for player_stats in stats
             ]
         )
+
+    @property
+    def game_start(self) -> Optional[datetime.datetime]:
+        if self.status != 1:
+            return None
+
+        if not self.data.logs:
+            return None
+
+        return datetime.datetime.fromtimestamp(self.data.logs[0].time, tz=datetime.UTC)
+
+    @property
+    def game_end(self) -> Optional[datetime.datetime]:
+        if self.status != 1:
+            return None
+
+        if not self.data.logs:
+            return None
+
+        return datetime.datetime.fromtimestamp(self.data.logs[-1].time, tz=datetime.UTC)

--- a/ark_nova_stats/bga_log_parser/game_log.py
+++ b/ark_nova_stats/bga_log_parser/game_log.py
@@ -369,21 +369,21 @@ class GameLog:
         )
 
     @property
-    def game_start(self) -> Optional[datetime.datetime]:
+    def game_start(self) -> datetime.datetime:
         if self.status != 1:
-            return None
+            raise ValueError(f"Log for table ID {self.table_id} does not have a status")
 
         if not self.data.logs:
-            return None
+            raise ValueError(f"Log for table ID {self.table_id} does not have any logs")
 
         return datetime.datetime.fromtimestamp(self.data.logs[0].time, tz=datetime.UTC)
 
     @property
-    def game_end(self) -> Optional[datetime.datetime]:
+    def game_end(self) -> datetime.datetime:
         if self.status != 1:
-            return None
+            raise ValueError(f"Log for table ID {self.table_id} does not have a status")
 
         if not self.data.logs:
-            return None
+            raise ValueError(f"Log for table ID {self.table_id} does not have any logs")
 
         return datetime.datetime.fromtimestamp(self.data.logs[-1].time, tz=datetime.UTC)

--- a/ark_nova_stats/bga_log_parser/game_log_test.py
+++ b/ark_nova_stats/bga_log_parser/game_log_test.py
@@ -217,8 +217,8 @@ class TestGameLog:
             datetime.datetime(
                 year=2024,
                 month=7,
-                day=4,
-                hour=23,
+                day=5,
+                hour=3,
                 minute=25,
                 second=0,
                 tzinfo=datetime.UTC,

--- a/ark_nova_stats/bga_log_parser/game_log_test.py
+++ b/ark_nova_stats/bga_log_parser/game_log_test.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import sys
 from pathlib import Path
@@ -196,6 +197,34 @@ class TestGameLog:
         assert 1 == hardyzhao.icons_water
         assert 2 == hardyzhao.icons_rock
         assert 3 == hardyzhao.icons_science
+
+    def test_game_start_end_with_simple_game(self):
+        game_log = load_data_from_fixture_file("533468391_darcelmaw_hardyzhao.json")
+        x = GameLog(**game_log)
+        assert (
+            datetime.datetime(
+                year=2024,
+                month=7,
+                day=5,
+                hour=2,
+                minute=42,
+                second=51,
+                tzinfo=datetime.UTC,
+            )
+            == x.game_start
+        )
+        assert (
+            datetime.datetime(
+                year=2024,
+                month=7,
+                day=4,
+                hour=23,
+                minute=25,
+                second=0,
+                tzinfo=datetime.UTC,
+            )
+            == x.game_end
+        )
 
 
 class TestGameLogData:

--- a/ark_nova_stats/models.py
+++ b/ark_nova_stats/models.py
@@ -35,6 +35,8 @@ class GameLog(db.Model):
         default=lambda: datetime.datetime.now(tz=datetime.timezone.utc),
     )
     bga_table_id: Mapped[int]
+    game_start: Mapped[datetime.datetime]
+    game_end: Mapped[datetime.datetime]
 
     users: Mapped[list["User"]] = relationship(
         secondary="game_participations", back_populates="game_logs", viewonly=True


### PR DESCRIPTION
- **Add test covering game start & end**
- **Implement game_start, game_end**
- **Make field non-optional**
- **Add migration and database model**
- **Expose game start/end fields**
- **When submitting logs, record game start/end**
