### PR TITLE
Add support for string literals in proto-parser

### DIFF
--- a/proto_parser/tokenizer/BUILD.bazel
+++ b/proto_parser/tokenizer/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//proto_parser/tokenizer/floating_point_token",
         "//proto_parser/tokenizer/identifier_token",
         "//proto_parser/tokenizer/integer_token",
+        "//proto_parser/tokenizer/string_token",
         "//proto_parser/tokenizer/whitespace_token",
     ],
 )

--- a/proto_parser/tokenizer/string_token/BUILD.bazel
+++ b/proto_parser/tokenizer/string_token/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "string_token",
+    srcs = ["string_token.go"],
+    importpath = "github.com/shaldengeki/monorepo/proto_parser/tokenizer/string_token",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto_parser/proto:token_go_proto",
+        "//proto_parser/tokenizer/decimal_token",
+        "//proto_parser/tokenizer/errors",
+        "//proto_parser/tokenizer/hex_token",
+        "//proto_parser/tokenizer/octal_token",
+    ],
+)
+
+go_test(
+    name = "string_token_test",
+    srcs = ["string_token_test.go"],
+    embed = [":string_token"],
+    deps = [
+        "//proto_parser/tokenizer/errors",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+    ],
+)

--- a/proto_parser/tokenizer/string_token/BUILD.bazel
+++ b/proto_parser/tokenizer/string_token/BUILD.bazel
@@ -7,10 +7,10 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto_parser/proto:token_go_proto",
-        "//proto_parser/tokenizer/decimal_token",
         "//proto_parser/tokenizer/errors",
         "//proto_parser/tokenizer/hex_token",
         "//proto_parser/tokenizer/octal_token",
+        "//proto_parser/tokenizer/whitespace_token",
     ],
 )
 
@@ -19,6 +19,7 @@ go_test(
     srcs = ["string_token_test.go"],
     embed = [":string_token"],
     deps = [
+        "//proto_parser/proto:token_go_proto",
         "//proto_parser/tokenizer/errors",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",

--- a/proto_parser/tokenizer/string_token/string_token.go
+++ b/proto_parser/tokenizer/string_token/string_token.go
@@ -1,0 +1,52 @@
+package string_token
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	pbtoken "github.com/shaldengeki/monorepo/proto_parser/proto/token"
+	tokenErrors "github.com/shaldengeki/monorepo/proto_parser/tokenizer/errors"
+)
+
+func ParseStringSingleToken(ctx context.Context, start int, body string) (pbtoken.StringSingleToken, int, error) {
+	return pbtoken.StringSingleToken{}, start, fmt.Errorf("TODO")
+}
+
+func ParseStringToken(ctx context.Context, start int, body string) (pbtoken.Token, int, error) {
+	if start >= len(body) {
+		return pbtoken.Token{}, 0, fmt.Errorf("Cannot parse string literal in position %d in body of length %d", start, len(body))
+	}
+
+	var unparseableError *tokenErrors.TokenNotParseableError
+
+	idx := start
+	tokens := []*pbtoken.StringSingleToken{}
+
+	for {
+		tkn, newIdx, err := ParseStringSingleToken(ctx, idx, body)
+		if err == nil {
+			tokens = append(tokens, &tkn)
+			idx = newIdx
+
+			if idx >= len(body) {
+				break
+			}
+			continue
+		}
+
+		if errors.As(err, &unparseableError) {
+			return pbtoken.Token{}, 0, &tokenErrors.TokenNotParseableError{Message: fmt.Sprintf("body %s, start %d is not a parseable as an string literal", body, start)}
+		} else {
+			return pbtoken.Token{}, start, fmt.Errorf("Unexpected error when parsing string literal tokens at position %d: %w\nfor body: %s", idx, err, body)
+		}
+	}
+
+	return pbtoken.Token{
+		Token: &pbtoken.Token_StringToken{
+			StringToken: &pbtoken.StringToken{
+				StringLiterals: tokens,
+			},
+		},
+	}, idx, nil
+}

--- a/proto_parser/tokenizer/string_token/string_token.go
+++ b/proto_parser/tokenizer/string_token/string_token.go
@@ -8,6 +8,9 @@ import (
 
 	pbtoken "github.com/shaldengeki/monorepo/proto_parser/proto/token"
 	tokenErrors "github.com/shaldengeki/monorepo/proto_parser/tokenizer/errors"
+	"github.com/shaldengeki/monorepo/proto_parser/tokenizer/hex_token"
+	"github.com/shaldengeki/monorepo/proto_parser/tokenizer/octal_token"
+	"github.com/shaldengeki/monorepo/proto_parser/tokenizer/whitespace_token"
 )
 
 func IsStringQuote(s string) bool {
@@ -52,15 +55,93 @@ func ParseSimpleEscapeSequence(ctx context.Context, start int, body string, open
 }
 
 func ParseHexEscapeSequence(ctx context.Context, start int, body string, openingQuote string) (string, int, error) {
-	return "", 0, &tokenErrors.TokenNotParseableError{Message: "TODO"}
+	if start >= len(body) {
+		return "", 0, fmt.Errorf("Cannot parse hex escape in position %d in body of length %d", start, len(body))
+	}
+	if string(body[start]) != "\\" {
+		return "", 0, &tokenErrors.TokenNotParseableError{Message: fmt.Sprintf("body %s, position %d is not parseable as a hex escape", body, start)}
+	}
+
+	currIdx := 1
+	stringToScan := string(body[start+currIdx:])
+
+	for idx, r := range stringToScan {
+		currIdx = idx + 1
+		if idx == 0 {
+			if !hex_token.IsHexLeadingRune(r) {
+				return "", 0, &tokenErrors.TokenNotParseableError{Message: fmt.Sprintf("body %s, position %d does not start with x or X", stringToScan, idx)}
+			}
+		} else if !hex_token.IsHexRune(r) {
+			break
+		}
+	}
+
+	if currIdx <= 2 {
+		return "", 0, &tokenErrors.TokenNotParseableError{Message: fmt.Sprintf("body %s, position %d is not a valid hex value", stringToScan, currIdx)}
+	}
+
+	return string(body[start : start+currIdx]), start + currIdx, nil
 }
 
 func ParseOctalEscapeSequence(ctx context.Context, start int, body string, openingQuote string) (string, int, error) {
-	return "", 0, &tokenErrors.TokenNotParseableError{Message: "TODO"}
+	if start >= len(body) {
+		return "", 0, fmt.Errorf("Cannot parse octal escape in position %d in body of length %d", start, len(body))
+	}
+	if string(body[start]) != "\\" {
+		return "", 0, &tokenErrors.TokenNotParseableError{Message: fmt.Sprintf("body %s, position %d is not parseable as a octal escape", body, start)}
+	}
+
+	currIdx := 1
+	stringToScan := string(body[start+currIdx:])
+
+	for idx, r := range stringToScan {
+		currIdx = idx + 1
+		if !octal_token.IsOctalRune(r) {
+			break
+		}
+	}
+
+	if currIdx <= 1 {
+		return "", 0, &tokenErrors.TokenNotParseableError{Message: fmt.Sprintf("body %s, position %d is not a valid octal value", stringToScan, currIdx)}
+	}
+
+	return string(body[start : start+currIdx]), start + currIdx, nil
 }
 
 func ParseUnicodeEscapeSequence(ctx context.Context, start int, body string, openingQuote string) (string, int, error) {
-	return "", 0, &tokenErrors.TokenNotParseableError{Message: "TODO"}
+	if start >= len(body) {
+		return "", 0, fmt.Errorf("Cannot parse unicode escape in position %d in body of length %d", start, len(body))
+	}
+
+	currIdx := start
+
+	if string(body[currIdx]) != "\\" {
+		return "", 0, &tokenErrors.TokenNotParseableError{Message: fmt.Sprintf("body %s, position %d is not parseable as a unicode escape", body, currIdx)}
+	}
+	currIdx += 1
+
+	stringToScan := ""
+	if string(body[currIdx]) == "u" {
+		// Four digits
+		stringToScan = string(body[currIdx+1 : currIdx+5])
+		currIdx += 5
+	} else if string(body[currIdx]) == "U" {
+		// Eight digits
+		stringToScan = string(body[currIdx+1 : currIdx+9])
+		currIdx += 9
+	} else {
+		// Invalid
+		return "", 0, &tokenErrors.TokenNotParseableError{Message: fmt.Sprintf("body %s, position %d is not parseable as a unicode escape", body, currIdx)}
+	}
+
+	// Every character should be a hex digit
+	for _, r := range stringToScan {
+		if !hex_token.IsHexRune(r) {
+			return "", 0, &tokenErrors.TokenNotParseableError{Message: fmt.Sprintf("body %s, position %d is not parseable as a unicode escape (non-hex digit)", stringToScan, currIdx)}
+		}
+	}
+
+	return string(body[start:currIdx]), currIdx, nil
 }
 
 func ParseStringSingleToken(ctx context.Context, start int, body string) (pbtoken.StringSingleToken, int, error) {
@@ -143,11 +224,22 @@ func ParseStringToken(ctx context.Context, start int, body string) (pbtoken.Toke
 			continue
 		}
 
-		if errors.As(parseErr, &unparseableError) {
-			lastErr = parseErr
-			break
-		} else {
+		if !errors.As(parseErr, &unparseableError) {
 			return pbtoken.Token{}, start, fmt.Errorf("Unexpected error when parsing string literal tokens at position %d: %w\nfor body: %s", idx, parseErr, body)
+		}
+		lastErr = parseErr
+
+		// See if this is whitespace.
+		_, newIdx, whitespaceErr := whitespace_token.ParseWhitespaceToken(ctx, idx, body)
+		if whitespaceErr == nil {
+			idx = newIdx
+
+			if idx >= len(body) {
+				break
+			}
+		}
+		if !errors.As(parseErr, &unparseableError) {
+			return pbtoken.Token{}, start, fmt.Errorf("Unexpected error when parsing string literal tokens (whitespace) at position %d: %w\nfor body: %s", idx, parseErr, body)
 		}
 	}
 

--- a/proto_parser/tokenizer/string_token/string_token.go
+++ b/proto_parser/tokenizer/string_token/string_token.go
@@ -9,8 +9,85 @@ import (
 	tokenErrors "github.com/shaldengeki/monorepo/proto_parser/tokenizer/errors"
 )
 
+func IsStringQuote(s string) bool {
+	return s == "\"" || s == "'"
+}
+
+func ParseRegularString(ctx context.Context, start int, body string, openingQuote string) (string, int, error) {
+	return "", 0, &tokenErrors.TokenNotParseableError{Message: "TODO"}
+}
+
+func ParseSimpleEscapeSequence(ctx context.Context, start int, body string, openingQuote string) (string, int, error) {
+	return "", 0, &tokenErrors.TokenNotParseableError{Message: "TODO"}
+}
+
+func ParseHexEscapeSequence(ctx context.Context, start int, body string, openingQuote string) (string, int, error) {
+	return "", 0, &tokenErrors.TokenNotParseableError{Message: "TODO"}
+}
+
+func ParseOctalEscapeSequence(ctx context.Context, start int, body string, openingQuote string) (string, int, error) {
+	return "", 0, &tokenErrors.TokenNotParseableError{Message: "TODO"}
+}
+
+func ParseUnicodeEscapeSequence(ctx context.Context, start int, body string, openingQuote string) (string, int, error) {
+	return "", 0, &tokenErrors.TokenNotParseableError{Message: "TODO"}
+}
+
 func ParseStringSingleToken(ctx context.Context, start int, body string) (pbtoken.StringSingleToken, int, error) {
-	return pbtoken.StringSingleToken{}, start, fmt.Errorf("TODO")
+	openingQuote := string(body[start])
+	if !IsStringQuote(openingQuote) {
+		return pbtoken.StringSingleToken{}, 0, &tokenErrors.TokenNotParseableError{Message: fmt.Sprintf("body %s, start %d does not start with a string quote", body, start)}
+	}
+	start += 1
+
+	if start >= len(body) {
+		return pbtoken.StringSingleToken{}, 0, &tokenErrors.TokenNotParseableError{Message: fmt.Sprintf("body %s, start %d is just a single quote", body, start)}
+	}
+
+	parseFuncs := []func(context.Context, int, string, string) (string, int, error){
+		ParseRegularString,
+		ParseSimpleEscapeSequence,
+		ParseHexEscapeSequence,
+		ParseOctalEscapeSequence,
+		ParseUnicodeEscapeSequence,
+	}
+
+	idx := start
+	var unparseableError *tokenErrors.TokenNotParseableError
+
+	for {
+		prevIdx := idx
+		for _, f := range parseFuncs {
+			_, newIdx, err := f(ctx, idx, body, openingQuote)
+			if err == nil {
+				idx = newIdx
+				break
+			}
+			if !errors.As(err, &unparseableError) {
+				return pbtoken.StringSingleToken{}, 0, fmt.Errorf("Unexpected error when parsing single string tokens at position %d: %w\nfor body: %s", idx, err, body)
+			}
+		}
+		if idx == prevIdx || idx >= len(body) {
+			break
+		}
+	}
+
+	// We should now be pointing at an end quote, matching the leading quote.
+	if string(body[idx]) != openingQuote {
+		return pbtoken.StringSingleToken{}, 0, &tokenErrors.TokenNotParseableError{Message: fmt.Sprintf("body %s, position %d does not end with a string quote matching leading quote %s", body, idx, openingQuote)}
+	}
+
+	quoteType := pbtoken.QuotationMarkType_QUOTATION_MARK_TYPE_UNKNOWN
+	if openingQuote == "\"" {
+		quoteType = pbtoken.QuotationMarkType_QUOTATION_MARK_TYPE_DOUBLE
+	} else if openingQuote == "'" {
+		quoteType = pbtoken.QuotationMarkType_QUOTATION_MARK_TYPE_SINGLE
+	}
+
+	return pbtoken.StringSingleToken{
+		QuotationMarkType: quoteType,
+		Value:             string(body[start:idx]),
+	}, idx + 1, nil
 }
 
 func ParseStringToken(ctx context.Context, start int, body string) (pbtoken.Token, int, error) {
@@ -36,7 +113,7 @@ func ParseStringToken(ctx context.Context, start int, body string) (pbtoken.Toke
 		}
 
 		if errors.As(err, &unparseableError) {
-			return pbtoken.Token{}, 0, &tokenErrors.TokenNotParseableError{Message: fmt.Sprintf("body %s, start %d is not a parseable as an string literal", body, start)}
+			return pbtoken.Token{}, 0, &tokenErrors.TokenNotParseableError{Message: fmt.Sprintf("body %s, start %d is not a parseable as a string literal: %w", body, start, err)}
 		} else {
 			return pbtoken.Token{}, start, fmt.Errorf("Unexpected error when parsing string literal tokens at position %d: %w\nfor body: %s", idx, err, body)
 		}

--- a/proto_parser/tokenizer/string_token/string_token_test.go
+++ b/proto_parser/tokenizer/string_token/string_token_test.go
@@ -103,14 +103,14 @@ func TestParseStringToken_WithSimpleEscapes_ReturnsSimpleEscapes(t *testing.T) {
 
 func TestParseStringToken_WithMixedEscapesAndCharacters_ReturnsMixture(t *testing.T) {
 	ctx := context.Background()
-	body := "\"test asd\\nf)S(Dn8fy\\x0Afs0f(*NSD))\" foo bar"
+	body := "\"test asd\\nf)S\\012345(Dn8fy\\x0Afs0\\u0FA3f(*NSD))\" foo bar"
 	res, idx, err := ParseStringToken(ctx, 0, body)
 	require.NoError(t, err)
 	require.NotNil(t, res.GetStringToken())
 	assert.Equal(t, 1, len(res.GetStringToken().StringLiterals))
 	assert.Equal(t, pbtoken.QuotationMarkType_QUOTATION_MARK_TYPE_DOUBLE, res.GetStringToken().StringLiterals[0].QuotationMarkType)
-	assert.Equal(t, "test asd\\nf)S(Dn8fy\\x0Afs0f(*NSD))", res.GetStringToken().StringLiterals[0].Value)
-	assert.Equal(t, 34, idx)
+	assert.Equal(t, "test asd\\nf)S\\012345(Dn8fy\\x0Afs0\\u0FA3f(*NSD))", res.GetStringToken().StringLiterals[0].Value)
+	assert.Equal(t, 49, idx)
 }
 
 func TestParseStringToken_WithMultipleLiterals_ReturnsAllLiterals(t *testing.T) {
@@ -119,10 +119,10 @@ func TestParseStringToken_WithMultipleLiterals_ReturnsAllLiterals(t *testing.T) 
 	res, idx, err := ParseStringToken(ctx, 0, body)
 	require.NoError(t, err)
 	require.NotNil(t, res.GetStringToken())
-	require.Equal(t, 2, len(res.GetStringToken().StringLiterals))
+	assert.Equal(t, 2, len(res.GetStringToken().StringLiterals))
 	assert.Equal(t, pbtoken.QuotationMarkType_QUOTATION_MARK_TYPE_DOUBLE, res.GetStringToken().StringLiterals[0].QuotationMarkType)
 	assert.Equal(t, "foo bar\\r\\n", res.GetStringToken().StringLiterals[0].Value)
 	assert.Equal(t, pbtoken.QuotationMarkType_QUOTATION_MARK_TYPE_SINGLE, res.GetStringToken().StringLiterals[1].QuotationMarkType)
 	assert.Equal(t, "baz bat", res.GetStringToken().StringLiterals[1].Value)
-	assert.Equal(t, 21, idx)
+	assert.Equal(t, 23, idx)
 }

--- a/proto_parser/tokenizer/string_token/string_token_test.go
+++ b/proto_parser/tokenizer/string_token/string_token_test.go
@@ -1,0 +1,128 @@
+package string_token
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pbtoken "github.com/shaldengeki/monorepo/proto_parser/proto/token"
+	tokenErrors "github.com/shaldengeki/monorepo/proto_parser/tokenizer/errors"
+)
+
+func TestParseStringToken_WithEmptyString_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	_, _, err := ParseStringToken(ctx, 0, "")
+	assert.NotNil(t, err)
+}
+
+func TestParseStringToken_WithNoQuotes_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	_, _, err := ParseStringToken(ctx, 0, "foo")
+	require.Error(t, err)
+	var errType *tokenErrors.TokenNotParseableError
+	assert.ErrorAs(t, err, &errType)
+}
+
+func TestParseStringToken_WithUnmatchedQuotes_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	invalidCases := []string{
+		"'foo\"",
+		"\"foo'",
+		"'",
+		"\"",
+	}
+	for _, invalidCase := range invalidCases {
+		_, _, err := ParseStringToken(ctx, 0, invalidCase)
+		require.Error(t, err)
+		var errType *tokenErrors.TokenNotParseableError
+		assert.ErrorAs(t, err, &errType)
+	}
+}
+
+func TestParseStringToken_WithEmptySingleQuotes_ReturnsEmptyLiteral(t *testing.T) {
+	ctx := context.Background()
+	body := "''"
+	res, idx, err := ParseStringToken(ctx, 0, body)
+	require.NoError(t, err)
+	require.NotNil(t, res.GetStringToken())
+	assert.Equal(t, 1, len(res.GetStringToken().StringLiterals))
+	assert.Equal(t, pbtoken.QuotationMarkType_QUOTATION_MARK_TYPE_SINGLE, res.GetStringToken().StringLiterals[0].QuotationMarkType)
+	assert.Equal(t, "", res.GetStringToken().StringLiterals[0].Value)
+	assert.Equal(t, len(body), idx)
+}
+
+func TestParseStringToken_WithEmptyDoubleQuotes_ReturnsEmptyLiteral(t *testing.T) {
+	ctx := context.Background()
+	body := "\"\""
+	res, idx, err := ParseStringToken(ctx, 0, body)
+	require.NoError(t, err)
+	require.NotNil(t, res.GetStringToken())
+	assert.Equal(t, 1, len(res.GetStringToken().StringLiterals))
+	assert.Equal(t, pbtoken.QuotationMarkType_QUOTATION_MARK_TYPE_DOUBLE, res.GetStringToken().StringLiterals[0].QuotationMarkType)
+	assert.Equal(t, "", res.GetStringToken().StringLiterals[0].Value)
+	assert.Equal(t, len(body), idx)
+}
+
+func TestParseStringToken_WithSingleQuotedString_ReturnsSingleString(t *testing.T) {
+	ctx := context.Background()
+	body := "'test asdf)S(Dn8fys0f(*NSD))' foo bar"
+	res, idx, err := ParseStringToken(ctx, 0, body)
+	require.NoError(t, err)
+	require.NotNil(t, res.GetStringToken())
+	assert.Equal(t, 1, len(res.GetStringToken().StringLiterals))
+	assert.Equal(t, pbtoken.QuotationMarkType_QUOTATION_MARK_TYPE_SINGLE, res.GetStringToken().StringLiterals[0].QuotationMarkType)
+	assert.Equal(t, "test asdf)S(Dn8fys0f(*NSD))", res.GetStringToken().StringLiterals[0].Value)
+	assert.Equal(t, 29, idx)
+}
+
+func TestParseStringToken_WithDoubleQuotedString_ReturnsSingleString(t *testing.T) {
+	ctx := context.Background()
+	body := "\"test asdf)S(Dn8fys0f(*NSD))\" foo bar"
+	res, idx, err := ParseStringToken(ctx, 0, body)
+	require.NoError(t, err)
+	require.NotNil(t, res.GetStringToken())
+	assert.Equal(t, 1, len(res.GetStringToken().StringLiterals))
+	assert.Equal(t, pbtoken.QuotationMarkType_QUOTATION_MARK_TYPE_DOUBLE, res.GetStringToken().StringLiterals[0].QuotationMarkType)
+	assert.Equal(t, "test asdf)S(Dn8fys0f(*NSD))", res.GetStringToken().StringLiterals[0].Value)
+	assert.Equal(t, 29, idx)
+}
+
+func TestParseStringToken_WithCharEscapes_ReturnsCharEscapes(t *testing.T) {
+	ctx := context.Background()
+	body := "\"\r\n\" foo bar"
+	res, idx, err := ParseStringToken(ctx, 0, body)
+	require.NoError(t, err)
+	require.NotNil(t, res.GetStringToken())
+	assert.Equal(t, 1, len(res.GetStringToken().StringLiterals))
+	assert.Equal(t, pbtoken.QuotationMarkType_QUOTATION_MARK_TYPE_DOUBLE, res.GetStringToken().StringLiterals[0].QuotationMarkType)
+	assert.Equal(t, "\r\n", res.GetStringToken().StringLiterals[0].Value)
+	assert.Equal(t, 4, idx)
+}
+
+func TestParseStringToken_WithMixedEscapesAndCharacters_ReturnsMixture(t *testing.T) {
+	ctx := context.Background()
+	body := "\"test asd\nf)S(Dn8fy\r0Afs0f(*NSD))\" foo bar"
+	res, idx, err := ParseStringToken(ctx, 0, body)
+	require.NoError(t, err)
+	require.NotNil(t, res.GetStringToken())
+	assert.Equal(t, 1, len(res.GetStringToken().StringLiterals))
+	assert.Equal(t, pbtoken.QuotationMarkType_QUOTATION_MARK_TYPE_DOUBLE, res.GetStringToken().StringLiterals[0].QuotationMarkType)
+	assert.Equal(t, "test asd\nf)S(Dn8fy\x0Afs0f(*NSD))", res.GetStringToken().StringLiterals[0].Value)
+	assert.Equal(t, 34, idx)
+}
+
+func TestParseStringToken_WithMultipleLiterals_ReturnsAllLiterals(t *testing.T) {
+	ctx := context.Background()
+	body := "\"foo bar\r\n\" 'baz bat'"
+	res, idx, err := ParseStringToken(ctx, 0, body)
+	require.NoError(t, err)
+	require.NotNil(t, res.GetStringToken())
+	assert.Equal(t, 2, len(res.GetStringToken().StringLiterals))
+	assert.Equal(t, pbtoken.QuotationMarkType_QUOTATION_MARK_TYPE_DOUBLE, res.GetStringToken().StringLiterals[0].QuotationMarkType)
+	assert.Equal(t, "foo bar \r\n", res.GetStringToken().StringLiterals[0].Value)
+	assert.Equal(t, pbtoken.QuotationMarkType_QUOTATION_MARK_TYPE_SINGLE, res.GetStringToken().StringLiterals[1].QuotationMarkType)
+	assert.Equal(t, "baz bat", res.GetStringToken().StringLiterals[1].Value)
+	assert.Equal(t, 21, idx)
+}

--- a/proto_parser/tokenizer/string_token/string_token_test.go
+++ b/proto_parser/tokenizer/string_token/string_token_test.go
@@ -89,39 +89,39 @@ func TestParseStringToken_WithDoubleQuotedString_ReturnsSingleString(t *testing.
 	assert.Equal(t, 29, idx)
 }
 
-func TestParseStringToken_WithCharEscapes_ReturnsCharEscapes(t *testing.T) {
+func TestParseStringToken_WithSimpleEscapes_ReturnsSimpleEscapes(t *testing.T) {
 	ctx := context.Background()
-	body := "\"\r\n\" foo bar"
+	body := "\"\\r\\n\" foo bar"
 	res, idx, err := ParseStringToken(ctx, 0, body)
 	require.NoError(t, err)
 	require.NotNil(t, res.GetStringToken())
 	assert.Equal(t, 1, len(res.GetStringToken().StringLiterals))
 	assert.Equal(t, pbtoken.QuotationMarkType_QUOTATION_MARK_TYPE_DOUBLE, res.GetStringToken().StringLiterals[0].QuotationMarkType)
-	assert.Equal(t, "\r\n", res.GetStringToken().StringLiterals[0].Value)
-	assert.Equal(t, 4, idx)
+	assert.Equal(t, "\\r\\n", res.GetStringToken().StringLiterals[0].Value)
+	assert.Equal(t, 6, idx)
 }
 
 func TestParseStringToken_WithMixedEscapesAndCharacters_ReturnsMixture(t *testing.T) {
 	ctx := context.Background()
-	body := "\"test asd\nf)S(Dn8fy\r0Afs0f(*NSD))\" foo bar"
+	body := "\"test asd\\nf)S(Dn8fy\\x0Afs0f(*NSD))\" foo bar"
 	res, idx, err := ParseStringToken(ctx, 0, body)
 	require.NoError(t, err)
 	require.NotNil(t, res.GetStringToken())
 	assert.Equal(t, 1, len(res.GetStringToken().StringLiterals))
 	assert.Equal(t, pbtoken.QuotationMarkType_QUOTATION_MARK_TYPE_DOUBLE, res.GetStringToken().StringLiterals[0].QuotationMarkType)
-	assert.Equal(t, "test asd\nf)S(Dn8fy\x0Afs0f(*NSD))", res.GetStringToken().StringLiterals[0].Value)
+	assert.Equal(t, "test asd\\nf)S(Dn8fy\\x0Afs0f(*NSD))", res.GetStringToken().StringLiterals[0].Value)
 	assert.Equal(t, 34, idx)
 }
 
 func TestParseStringToken_WithMultipleLiterals_ReturnsAllLiterals(t *testing.T) {
 	ctx := context.Background()
-	body := "\"foo bar\r\n\" 'baz bat'"
+	body := "\"foo bar\\r\\n\" 'baz bat'"
 	res, idx, err := ParseStringToken(ctx, 0, body)
 	require.NoError(t, err)
 	require.NotNil(t, res.GetStringToken())
-	assert.Equal(t, 2, len(res.GetStringToken().StringLiterals))
+	require.Equal(t, 2, len(res.GetStringToken().StringLiterals))
 	assert.Equal(t, pbtoken.QuotationMarkType_QUOTATION_MARK_TYPE_DOUBLE, res.GetStringToken().StringLiterals[0].QuotationMarkType)
-	assert.Equal(t, "foo bar \r\n", res.GetStringToken().StringLiterals[0].Value)
+	assert.Equal(t, "foo bar\\r\\n", res.GetStringToken().StringLiterals[0].Value)
 	assert.Equal(t, pbtoken.QuotationMarkType_QUOTATION_MARK_TYPE_SINGLE, res.GetStringToken().StringLiterals[1].QuotationMarkType)
 	assert.Equal(t, "baz bat", res.GetStringToken().StringLiterals[1].Value)
 	assert.Equal(t, 21, idx)

--- a/proto_parser/tokenizer/string_token/string_token_test.go
+++ b/proto_parser/tokenizer/string_token/string_token_test.go
@@ -110,7 +110,7 @@ func TestParseStringToken_WithMixedEscapesAndCharacters_ReturnsMixture(t *testin
 	assert.Equal(t, 1, len(res.GetStringToken().StringLiterals))
 	assert.Equal(t, pbtoken.QuotationMarkType_QUOTATION_MARK_TYPE_DOUBLE, res.GetStringToken().StringLiterals[0].QuotationMarkType)
 	assert.Equal(t, "test asd\\nf)S\\012345(Dn8fy\\x0Afs0\\u0FA3f(*NSD))", res.GetStringToken().StringLiterals[0].Value)
-	assert.Equal(t, 49, idx)
+	assert.Equal(t, 50, idx)
 }
 
 func TestParseStringToken_WithMultipleLiterals_ReturnsAllLiterals(t *testing.T) {

--- a/proto_parser/tokenizer/string_token/string_token_test.go
+++ b/proto_parser/tokenizer/string_token/string_token_test.go
@@ -110,7 +110,7 @@ func TestParseStringToken_WithMixedEscapesAndCharacters_ReturnsMixture(t *testin
 	assert.Equal(t, 1, len(res.GetStringToken().StringLiterals))
 	assert.Equal(t, pbtoken.QuotationMarkType_QUOTATION_MARK_TYPE_DOUBLE, res.GetStringToken().StringLiterals[0].QuotationMarkType)
 	assert.Equal(t, "test asd\\nf)S\\012345(Dn8fy\\x0Afs0\\u0FA3f(*NSD))", res.GetStringToken().StringLiterals[0].Value)
-	assert.Equal(t, 50, idx)
+	assert.Equal(t, 49, idx)
 }
 
 func TestParseStringToken_WithMultipleLiterals_ReturnsAllLiterals(t *testing.T) {

--- a/proto_parser/tokenizer/tokenizer.go
+++ b/proto_parser/tokenizer/tokenizer.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	pbtoken "github.com/shaldengeki/monorepo/proto_parser/proto/token"
 	"github.com/shaldengeki/monorepo/proto_parser/tokenizer/boolean_token"
+	tokenErrors "github.com/shaldengeki/monorepo/proto_parser/tokenizer/errors"
+	"github.com/shaldengeki/monorepo/proto_parser/tokenizer/floating_point_token"
 	"github.com/shaldengeki/monorepo/proto_parser/tokenizer/identifier_token"
 	"github.com/shaldengeki/monorepo/proto_parser/tokenizer/integer_token"
+	"github.com/shaldengeki/monorepo/proto_parser/tokenizer/string_token"
 	"github.com/shaldengeki/monorepo/proto_parser/tokenizer/whitespace_token"
-	"github.com/shaldengeki/monorepo/proto_parser/tokenizer/floating_point_token"
-	tokenErrors "github.com/shaldengeki/monorepo/proto_parser/tokenizer/errors"
 )
-
 
 func Tokenize(ctx context.Context, body string) ([]pbtoken.Token, error) {
 	pos := 0
@@ -25,12 +26,13 @@ func Tokenize(ctx context.Context, body string) ([]pbtoken.Token, error) {
 	// To add support for a new parseable token, add a function into this list.
 	// The function should return TokenNotParseableError when the current string doesn't match the token type (but could be a valid token),
 	// and any other error when the string is definitely invalid.
-	parseFuncs := []func(context.Context, int, string)(pbtoken.Token, int, error){
+	parseFuncs := []func(context.Context, int, string) (pbtoken.Token, int, error){
 		whitespace_token.ParseWhitespaceToken,
 		boolean_token.ParseBooleanToken,
 		identifier_token.ParseIdentifierToken,
 		floating_point_token.ParseFloatingPointToken,
 		integer_token.ParseIntegerToken,
+		string_token.ParseStringToken,
 	}
 
 	var unparseableError *tokenErrors.TokenNotParseableError


### PR DESCRIPTION
- **:necktie: Add string token framework & tests**
- **:money_with_wings: [wip] Partially implement string literal parsing**
- **:wastebasket: [wip] Implement regular string parsing**
- **:beers: [wip] Implement simple escape sequences**
- **:construction_worker: Implement octal, unicode escapes**
